### PR TITLE
Set permissions explicitly for diff-poetry-lock CI job

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -9,12 +9,16 @@ on:
 jobs:
   poetry-checks:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
     # This will post a comment on PRs when poetry.lock changes
     - name: Diff poetry.lock
       uses: nborrmann/diff-poetry-lock@c0afd3666864cec339f03ee5c5cf9cb671780c12
+
 
   build:
     strategy:


### PR DESCRIPTION
I'm seeing 403 errors in PR CI jobs, so I think the defaults for the Target org GITHUB_TOKEN may be too strict.

```
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://api.github.com/repos/target/make-python-devex/issues/20/comments
```