### PR TITLE
Clarify make usage slightly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ PYTEST ?= $(POETRY) run pytest
 
 .PHONY: help
 help: ## Display this help
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 .PHONY: debug-make
 debug-make: ## Shows ~all runtime-set variables


### PR DESCRIPTION
I noticed that the `make help` target had some ANSI escape sequences
that didn't seem to do anything:

    @awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"}

Those escape sequences at the end mean "change the color to blue, then
change it back to normal".

I've seen this pattern copy-pasted around the web for a while, so I was
curious to find what it was originally. I did some historical
spelunking. The earliest example I can find that closely matches this
branch of history is this:
https://www.thapaliya.com/en/writings/well-documented-makefiles/

In this version, there used to be a `<target>` inside the color
sequences. I can see why that might be helpful. Otherwise, why have the
first line that prints make at all?

```
Usage:
  make <target>
  help        Display this help
  deps        Check dependencies
  clean       Cleanup the project folders
```

Other options:

- Delete the escape sequences but leave the printable output the same:
  ```
  Usage:
    make
    help        Display this help
    deps        Check dependencies
    clean       Cleanup the project folders
  ```

- Delete the `make` line and possibly replace the heading with `Targets:`:
  ```
  Targets:
    help        Display this help
    deps        Check dependencies
    clean       Cleanup the project folders
  ```

- Restore `<target>` and `Targets:` as in the original:
  ```
  Usage:
    make <target>
  
  Targets:
    help        Display this help
    deps        Check dependencies
    clean       Cleanup the project folders
  ```

- Do nothing because this is a tiny detail that doesn't matter. 🙂 