### PR TITLE
Pass --fix to ruff as an option to check, not to ruff itself

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,12 +118,12 @@ check: check-py-ruff-format check-py-ruff-lint check-py-mypy ## Run all checks
 
 .PHONY: check-py-ruff-lint
 check-py-ruff-lint: ## Run ruff linter
-	$(RUFF) $(RUFF_OPTS) check $(MODULE_BASE_DIR) $(TESTS_BASE_DIR) || \
+	$(RUFF) $(RUFF_OPTS) check $(RUFF_CHECK_OPTS) $(MODULE_BASE_DIR) $(TESTS_BASE_DIR) || \
 		(echo "$(COLOR_RED)Run '$(notdir $(MAKE)) check-py-ruff-fix' to fix some of these automatically if [*] appears above, then run '$(notdir $(MAKE)) $(MAKECMDGOALS)' again." && false)
 
 .PHONY: check-py-ruff-fix
 check-py-ruff-fix: ## Run ruff linter
-	$(MAKE) check-py-ruff-lint RUFF_OPTS=--fix
+	$(MAKE) check-py-ruff-lint RUFF_CHECK_OPTS=--fix
 
 .PHONY: check-py-black
 check-py-black: ## Runs black code formatter


### PR DESCRIPTION
This changed in more recent versions of ruff.