### PR TITLE
Install Hadolint when git ls-files reports *Dockerfile* anywhere in the tree

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -9,7 +9,7 @@ brew "pyenv"
 # Manage virtualenvs with Pyenv just in case
 brew "pyenv-virtualenv"
 # Dockerfile linting, but only if we have Dockerfiles
-brew "hadolint" unless %x[find . -iname Dockerfile].empty?
+brew "hadolint" unless %x[git ls-files '*Dockerfile*'].empty?
 # Pre-commit checks, if we have a config
 brew "pre-commit" if File.exist?(".pre-commit-config.yaml")
 


### PR DESCRIPTION
This demonstration/template repo has one Dockerfile, but some other repos using this template have multiple Dockerfiles. Let's use something that works for all patterns:

```
Dockerfile
something.Dockerfile
Dockerfile.something
```