### PR TITLE
Explicitly set Poetry version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dynamic = [ "version", "dependencies" ]
 [tool.poetry]
 version = "0.0.0"
 packages = [{include = "example", from = "src"}]
+requires-poetry = ">=2.0"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]


### PR DESCRIPTION
This may be necessary to get dependabot to use 2.x